### PR TITLE
Check for generator tag when checking for WordPress

### DIFF
--- a/lib/vane/wp_target.rb
+++ b/lib/vane/wp_target.rb
@@ -46,6 +46,8 @@ class WpTarget < WebSite
 
     if response.body =~ /["'][^"']*\/wp-content\/[^"']*["']/i
       wordpress = true
+    elsif response.body[%r{name="generator" content="wordpress #{'([^\r\n"\']+\.[^\r\n"\']+)'}"}i, 1]
+      wordpress = true
     else
 
       if has_xml_rpc?


### PR DESCRIPTION
Before doing an internet request, it's also good to check for the generator tag. It's a bit copy/paste now. So this could be done better.
