### PR TITLE
Add wp_uri method for the WordPress url

### DIFF
--- a/lib/common/models/wp_user.rb
+++ b/lib/common/models/wp_user.rb
@@ -24,7 +24,7 @@ class WpUser < WpItem
   # @return [ String ]
   def login_url
     unless @login_url
-      @login_url = @uri.merge('wp-login.php').to_s
+      @login_url = wp_uri.merge('wp-login.php').to_s
 
       # Let's check if the login url is redirected (to https url for example)
       if redirection = redirection(@login_url)

--- a/lib/common/models/wp_version/findable.rb
+++ b/lib/common/models/wp_version/findable.rb
@@ -186,7 +186,7 @@ class WpVersion < WpItem
     # @return [ String ] The version number
     def find_from_readme(target_uri)
       scan_url(
-        target_uri,
+        wp_url.to_s,
         %r{<br />\sversion #{version_pattern}}i,
         'readme.html'
       )

--- a/lib/vane/web_site.rb
+++ b/lib/vane/web_site.rb
@@ -38,7 +38,7 @@ class WebSite
   # See http://www.hixie.ch/specs/pingback/pingback-1.0#TOC2.3
   def xml_rpc_url
     unless @xmlrpc_url
-      @xmlrpc_url = @uri.merge('xmlrpc.php').to_s
+      @xmlrpc_url = wp_uri.merge('xmlrpc.php').to_s
     end
 
     @xmlrpc_url

--- a/lib/vane/wp_target.rb
+++ b/lib/vane/wp_target.rb
@@ -67,7 +67,7 @@ class WpTarget < WebSite
   end
 
   def login_url
-    url = @uri.merge('wp-login.php').to_s
+    url = wp_uri.merge('wp-login').to_s
 
     # Let's check if the login url is redirected (to https url for example)
     redirection = redirection(url)

--- a/lib/vane/wp_target/wp_custom_directories.rb
+++ b/lib/vane/wp_target/wp_custom_directories.rb
@@ -3,6 +3,23 @@
 class WpTarget < WebSite
   module WpCustomDirectories
 
+    # @return [ String ] The WordPress directory
+    def wp_uri
+      unless @wp_uri
+        index_body = Browser.get(@uri.to_s).body
+        uri = @uri.host + @uri.path
+        wp_path = index_body[/(?:href|src)\s*=\s*(?:"|').+#{Regexp.escape(uri)}([^"']+)\/(?:wp-includes)\/.*(?:"|')/i, 1]
+
+        if wp_path
+          @wp_uri = @uri.merge( wp_path + '/' )
+        else
+          @wp_uri = @uri
+        end
+      end
+
+      @wp_uri
+    end
+
     # @return [ String ] The wp-content directory
     def wp_content_dir
       unless @wp_content_dir

--- a/lib/vane/wp_target/wp_full_path_disclosure.rb
+++ b/lib/vane/wp_target/wp_full_path_disclosure.rb
@@ -13,7 +13,7 @@ class WpTarget < WebSite
 
     # @return [ String ]
     def full_path_disclosure_url
-      @uri.merge('wp-includes/rss-functions.php').to_s
+      wp_uri.merge('wp-includes/rss-functions.php').to_s
     end
 
   end

--- a/lib/vane/wp_target/wp_readme.rb
+++ b/lib/vane/wp_target/wp_readme.rb
@@ -20,7 +20,7 @@ class WpTarget < WebSite
 
     # @return [ String ] The readme URL
     def readme_url
-      @uri.merge('readme.html').to_s
+      wp_uri.merge('readme.html').to_s
     end
 
   end

--- a/lib/vane/wp_target/wp_registrable.rb
+++ b/lib/vane/wp_target/wp_registrable.rb
@@ -26,7 +26,7 @@ class WpTarget < WebSite
 
     # @return [ String ] The registration URL
     def registration_url
-      multisite? ? @uri.merge('wp-signup.php').to_s : @uri.merge('wp-login.php?action=register').to_s
+      multisite? ? wp_uri.merge('wp-signup.php').to_s : wp_uri.merge('wp-login.php?action=register').to_s
     end
 
     # @return [ Boolean ]
@@ -34,7 +34,7 @@ class WpTarget < WebSite
       unless @multisite
         # when multi site, there is no redirection or a redirect to the site itself
         # otherwise redirect to wp-login.php
-        resp = Browser.get(@uri.merge('wp-signup.php').to_s)
+        resp = Browser.get(wp_uri.merge('wp-signup.php').to_s)
 
         if resp.code == 302 and resp.headers_hash['location'] =~ /wp-login\.php\?action=register/
           @multisite = false


### PR DESCRIPTION
WordPress can be installed in a subfolder. This code creates a site vs home url. I haven't run the spec (no clue how yet). Also not all use cases have been handled yet. See:

lib/common/models/wp_version/findable.rb - find_from_readme
